### PR TITLE
Fix CPI Rd range in test

### DIFF
--- a/compiler1/module/Instructions/tests/test_instructions.py
+++ b/compiler1/module/Instructions/tests/test_instructions.py
@@ -266,7 +266,7 @@ def test_cpc():
 
 
 def test_cpi():
-    rds = range(0, 32)
+    rds = range(16, 32)
     rrs = range(0, 256)
     opcode = 0b0011 << 12
     for rd in rds:


### PR DESCRIPTION
Laut Instruction Set Manual ist bei der Instruction CPI der Wertebereich für Rd 16 ≤ d ≤ 31